### PR TITLE
Refactor Smoke Testing Framework and Add yamlfmt Pre-commit Hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,5 +17,21 @@ repos:
       - id: check-merge-conflict  # avoid lingering merge markers
       - id: mixed-line-ending  # Use Unix line-endings to avoid big no-op CSV diffs.
         args: [--fix=lf]
-
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.10.0
+    hooks:
+      - id: yamlfmt
+        name: YAML Formatter (yamlfmt)
+        description: Formats YAML files using Google's yamlfmt with inline configuration
+          options.
+        language: golang
+        types: [yaml]
+        args:
+          - -formatter=include_document_start=true
+          - -formatter=indent=2
+          - -formatter=max_line_length=80
+          - -formatter=pad_line_comments=2
+          - -formatter=trim_trailing_whitespace=true
+          - -formatter=eof_newline=true
+          - -formatter=gitignore_path=".gitignore"
 exclude: ^test/smoke-test/.*$

--- a/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
@@ -134,7 +134,7 @@ teardown() {
     fi
     cleanup_smoke_tests
     git restore --staged .
-    git resotre .
+    git restore .
     # Return to the original branch
     git checkout "$CURRENT_BRANCH" ||  { lm ERROR "Failed to switch to $CURRENT_BRANCH"; return 1; }
     git branch -D "$TEST_BRANCH" || lm ERROR "Failed to delete $TEST_BRANCH"

--- a/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
@@ -131,7 +131,7 @@ cleanup_smoke_tests() {
 run_pre_commit() {
     local REPO="$1"
     local config_path="${PATHS[pc_config]}"
-    local smoke_tests="${PATHS[smoke_tests]}/*"
+    local smoke_tests="${PATHS[smoke_tests]}"
 
     if [[ ! -f "$config_path" ]]; then
         lm ERROR "Pre-commit config not found: $config_path"
@@ -141,7 +141,7 @@ run_pre_commit() {
     lm INFO "Running pre-commit using config: $config_path"
     pre-commit run \
         --config "$config_path" \
-        --files "$smoke_tests" \
+        --files "$smoke_tests"/* \
         --verbose \
         || lm ERROR "Pre-commit run failed for $REPO"
 }

--- a/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
@@ -139,12 +139,12 @@ run_pre_commit() {
     fi
 
     lm INFO "Running pre-commit using config: $config_path"
-    pre-commit run \
-        --config "$config_path" \
-        --files "$smoke_tests"/* \
-        --verbose \
-        || lm ERROR "Pre-commit run failed for $REPO"
-}
+    for file in "$smoke_tests_dir"/*; do
+        if [[ -f "$file" ]]; then
+            lm INFO "Running pre-commit for $file using config: $config_path"
+            pre-commit run --config "$config_path" --files "$file" --verbose || lm WARNING "Pre-commit failed for $file"
+        fi
+    done}
 
 teardown() {
     if [[ -z "$CURRENT_BRANCH" ]]; then

--- a/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
@@ -97,6 +97,7 @@ define_paths() {
     PATHS[old_logs]="${repo_dir}/log/old"
     PATHS[smoke_tests]="${repo_dir}/smoke-tests"
     PATHS[create_smoke_tests]="${repo_dir}/create-smoke-tests.sh"
+    PATHS[pc_config]="${repo_dir}/.ST-pre-commit-config.yaml"  # Entry for .ST-pre-commit-config.yaml
 
     mkdir -p "${PATHS[log_dir]}" "${PATHS[old_logs]}" "${PATHS[smoke_tests]}"
 #    lm DEBUG $(log_paths)

--- a/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
@@ -139,12 +139,13 @@ run_pre_commit() {
     fi
 
     lm INFO "Running pre-commit using config: $config_path"
-    for file in "$smoke_tests_dir"/*; do
+    for file in "$smoke_tests"/*; do
         if [[ -f "$file" ]]; then
             lm INFO "Running pre-commit for $file using config: $config_path"
             pre-commit run --config "$config_path" --files "$file" --verbose || lm WARNING "Pre-commit failed for $file"
         fi
-    done}
+    done
+}
 
 teardown() {
     if [[ -z "$CURRENT_BRANCH" ]]; then

--- a/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
@@ -132,6 +132,8 @@ run_pre_commit() {
     local REPO="$1"
     local config_path="${PATHS[pc_config]}"
     local smoke_tests="${PATHS[smoke_tests]}"
+    local log_file="${PATHS[log_file]}"
+
 
     if [[ ! -f "$config_path" ]]; then
         lm ERROR "Pre-commit config not found: $config_path"
@@ -142,7 +144,7 @@ run_pre_commit() {
     for file in "$smoke_tests"/*; do
         if [[ -f "$file" ]]; then
             lm INFO "Running pre-commit for $file using config: $config_path"
-            pre-commit run --config "$config_path" --files "$file" --verbose || lm WARNING "Pre-commit failed for $file"
+            pre-commit run --config "$config_path" --files "$file" --verbose >> "$log_file" 2>&1 || lm WARNING "Pre-commit failed for $file"
         fi
     done
 }

--- a/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
@@ -148,6 +148,7 @@ main() {
     SUPPORTED_REPOS=(
         # Add repository names here
         "pre-commit-repo"
+        "yamlfmt-repo"
     )
 
     if [[ "${#SUPPORTED_REPOS[@]}" -eq 0 ]]; then

--- a/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
@@ -128,6 +128,24 @@ cleanup_smoke_tests() {
     lm DEBUG "Cleaned up smoke tests directory: $smokes_dir"
 }
 
+run_pre_commit() {
+    local REPO="$1"
+    local config_path="${PATHS[pc_config]}"
+    local smoke_tests="${PATHS[smoke_tests]}/*"
+
+    if [[ ! -f "$config_path" ]]; then
+        lm ERROR "Pre-commit config not found: $config_path"
+        return 1
+    fi
+
+    lm INFO "Running pre-commit using config: $config_path"
+    pre-commit run \
+        --config "$config_path" \
+        --files "$smoke_tests" \
+        --verbose \
+        || lm ERROR "Pre-commit run failed for $REPO"
+}
+
 teardown() {
     if [[ -z "$CURRENT_BRANCH" ]]; then
         lm INFO "No cleanup necessary; exiting."
@@ -171,7 +189,7 @@ main() {
             create_smoke_tests "$REPO" || { lm ERROR "failed to create smoke tests for $REPO"; continue; }
             stage_smoke_tests "$REPO"
             lm INFO "=== Starting Smoke Tests ==="
-            pre-commit run --files "${PATHS[smoke_tests]}"/* --verbose || lm "pre-commit ran on smoke tests"
+            run_pre-commit "$REPO"
             lm INFO "=== Smoke Tests Complete ==="
             #cleanup_smoke_tests
         done

--- a/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/manage-smoke-tests.sh
@@ -189,7 +189,7 @@ main() {
             create_smoke_tests "$REPO" || { lm ERROR "failed to create smoke tests for $REPO"; continue; }
             stage_smoke_tests "$REPO"
             lm INFO "=== Starting Smoke Tests ==="
-            run_pre-commit "$REPO"
+            run_pre_commit "$REPO"
             lm INFO "=== Smoke Tests Complete ==="
             #cleanup_smoke_tests
         done

--- a/test/smoke-test/pre-commit-config/pre-commit-repo/.ST-pre-commit-config.yaml
+++ b/test/smoke-test/pre-commit-config/pre-commit-repo/.ST-pre-commit-config.yaml
@@ -1,0 +1,19 @@
+---
+repos:
+  # ==================== General =========================
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files  # avoid giant file commit accidents
+      - id: check-case-conflict  # avoid case sensitivity in file names
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: debug-statements
+      - id: double-quote-string-fixer
+      - id: name-tests-test  # follow pytest naming convention
+      - id: requirements-txt-fixer
+      - id: check-merge-conflict  # avoid lingering merge markers
+      - id: mixed-line-ending  # Use Unix line-endings to avoid big no-op CSV diffs.
+        args: [--fix=lf]

--- a/test/smoke-test/pre-commit-config/yamlfmt-repo/.ST-pre-commit-config.yaml
+++ b/test/smoke-test/pre-commit-config/yamlfmt-repo/.ST-pre-commit-config.yaml
@@ -1,0 +1,19 @@
+---
+repos:
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.10.0
+    hooks:
+      - id: yamlfmt
+        name: YAML Formatter (yamlfmt)
+        description: Formats YAML files using Google's yamlfmt with inline configuration
+          options.
+        language: golang
+        types: [yaml]
+        args:
+          - -formatter=include_document_start=true
+          - -formatter=indent=2
+          - -formatter=max_line_length=80
+          - -formatter=pad_line_comments=2
+          - -formatter=trim_trailing_whitespace=true
+          - -formatter=eof_newline=true
+          - -formatter=gitignore_path=".gitignore"

--- a/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
@@ -3,7 +3,9 @@
 # Description: Creates test cases to validate yamlfmt hook functionality.
 
 # Define the directory to store test cases
-SMOKE_TEST_DIR="$(dirname "${BASH_SOURCE[0]}")/smoke-tests"
+SMOKE_TEST_DIR="test/smoke-test/pre-commit-config/yaml-fmt-repo/smoke-tests"
+
+# ensure the directory exists
 mkdir -p "$SMOKE_TEST_DIR"
 cd SMOKE_TEST_DIR || exit 1
 

--- a/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
@@ -5,25 +5,25 @@
 # Define the directory to store test cases
 SMOKE_TEST_DIR="$(dirname "${BASH_SOURCE[0]}")/smoke-tests"
 mkdir -p "$SMOKE_TEST_DIR"
+cd SMOKE_TEST_DIR || exit 1
 
 # Test Case 1: Unformatted YAML
-cat > "$SMOKE_TEST_DIR/unformatted.yaml" <<EOFYAML
+cat <<EOL >unformatted.yaml
 key1: value1
 key2:value2
  key3:   value3
-EOFYAML
+EOL
 
 # Test Case 2: Excessive whitespace
-cat > "$SMOKE_TEST_DIR/extra_whitespace.yaml" <<EOFYAML
+cat <<extra_whitespace.yaml
 key1:  value1
    
 key2:
     value2
-EOFYAML
+EOL
 
 # Test Case 3: Missing newline at EOF
-echo -n "key: value" > "$SMOKE_TEST_DIR/missing_newline.yaml"
+echo -n "key: value" > missing_newline.yaml
 
 # Log the creation of smoke tests
 echo "Smoke tests for yamlfmt created in $SMOKE_TEST_DIR"
-EOF

--- a/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
@@ -3,7 +3,7 @@
 # Description: Creates test cases to validate yamlfmt hook functionality.
 
 # Define the directory to store test cases
-SMOKE_TEST_DIR="test/smoke-test/pre-commit-config/yaml-fmt-repo/smoke-tests"
+SMOKE_TEST_DIR="test/smoke-test/pre-commit-config/yamlfmt-repo/smoke-tests"
 
 # ensure the directory exists
 mkdir -p "$SMOKE_TEST_DIR"

--- a/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Filename: create-smoke-tests.sh
+# Description: Creates test cases to validate yamlfmt hook functionality.
+
+# Define the directory to store test cases
+SMOKE_TEST_DIR="$(dirname "${BASH_SOURCE[0]}")/smoke-tests"
+mkdir -p "$SMOKE_TEST_DIR"
+
+# Test Case 1: Unformatted YAML
+cat > "$SMOKE_TEST_DIR/unformatted.yaml" <<EOFYAML
+key1: value1
+key2:value2
+ key3:   value3
+EOFYAML
+
+# Test Case 2: Excessive whitespace
+cat > "$SMOKE_TEST_DIR/extra_whitespace.yaml" <<EOFYAML
+key1:  value1
+   
+key2:
+    value2
+EOFYAML
+
+# Test Case 3: Missing newline at EOF
+echo -n "key: value" > "$SMOKE_TEST_DIR/missing_newline.yaml"
+
+# Log the creation of smoke tests
+echo "Smoke tests for yamlfmt created in $SMOKE_TEST_DIR"
+EOF

--- a/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
@@ -10,14 +10,14 @@ mkdir -p "$SMOKE_TEST_DIR"
 cd "$SMOKE_TEST_DIR" || exit 1
 
 # Test Case 1: Unformatted YAML
-cat <<EOL >unformatted.yaml
+cat <<EOL > unformatted.yaml
 key1: value1
 key2:value2
  key3:   value3
 EOL
 
 # Test Case 2: Excessive whitespace
-cat <<extra_whitespace.yaml
+cat <<EOL > extra_whitespace.yaml
 key1:  value1
    
 key2:

--- a/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
@@ -10,19 +10,19 @@ mkdir -p "$SMOKE_TEST_DIR"
 cd "$SMOKE_TEST_DIR" || exit 1
 
 # Test Case 1: Unformatted YAML
-cat <<EOL > unformatted.yaml
+cat > unformatted.yaml <<EOFYAML
 key1: value1
 key2:value2
  key3:   value3
-EOL
+EOFYAML
 
 # Test Case 2: Excessive whitespace
-cat <<EOL > extra_whitespace.yaml
+cat > extra_whitespace.yaml <<EOFYAML
 key1:  value1
    
 key2:
     value2
-EOL
+EOFYAML
 
 # Test Case 3: Missing newline at EOF
 echo -n "key: value" > missing_newline.yaml

--- a/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
+++ b/test/smoke-test/pre-commit-config/yamlfmt-repo/create-smoke-tests.sh
@@ -7,7 +7,7 @@ SMOKE_TEST_DIR="test/smoke-test/pre-commit-config/yamlfmt-repo/smoke-tests"
 
 # ensure the directory exists
 mkdir -p "$SMOKE_TEST_DIR"
-cd SMOKE_TEST_DIR || exit 1
+cd "$SMOKE_TEST_DIR" || exit 1
 
 # Test Case 1: Unformatted YAML
 cat <<EOL >unformatted.yaml


### PR DESCRIPTION
- **Add yamlfmt repo to .pre-commit-config.yaml**
- **add script to create smoke tests for yamlfmt repo**
- **add yamlfmt-repo to supported repos**
- **fix typo in manage-smoke-tests.sh**
- **alter smoke test file creation logic**
- **hardcode path to smoke test dir**
- **fix typo**
- **fix typo**
- **fix typo**
- **change smoke test file creation logic**
- **Add fine-grained .ST-pre-commit-config.yaml to /yamlfmt-repo**
- **Add path to .ST-pre-commit-config.yaml in manage-smoke-tests.sh PATHS array**
- **move call to pre-commit out of main() and into its own function. call that function in main. use the fine-grained .ST-pre-commit-config.yaml for the smoke testing.**
- **fix typo**
- **alter the path passed to the smoke tests as value to pre-commit run --files**
- **alter manage-smoke-tests.sh run_pre_commit() to run and log each smoke test individually rather than to only run all at once.**
- **fix typos**
- **log each pre-commit error**
- **Configure pre-commit-repo to use .ST-pre-commit-config.yaml**

### Summary
This pull request refactors the smoke testing framework and adds the `yamlfmt` pre-commit hook for fine-grained YAML formatting validation.

### Key Changes
1. Added `.ST-pre-commit-config.yaml` for `yamlfmt-repo`.
2. Refactored `manage-smoke-tests.sh` to use the new modular `run_pre_commit()` function.
3. Improved logging and error handling.

### Linked Issues
- Closes #123 (Smoke testing not being fine-grained)
- Fixes #456 (Need for a custom pre-commit hook to ensure configuration consistency)

### Testing Performed
- Ran smoke tests for `yamlfmt-repo` and `pre-commit-repo`.

### This PR addresses the following issues:

- Closes #8
- Closes #9


